### PR TITLE
npm ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - name: npm install
-      run: npm install --only=prod
+    - name: npm ci
+      run: npm ci
       working-directory: .
     - name: fetch
       run: node index.js


### PR DESCRIPTION
If you use npm ci, you’ll get reliable builds.